### PR TITLE
feat: migrate v3 search to support Tavily alongside DuckDuckGo

### DIFF
--- a/v3/SETTINGS.yaml
+++ b/v3/SETTINGS.yaml
@@ -9,6 +9,10 @@ MODEL_AUTH:
   api_key: "<Input Your API Key Here>"
 MODEL_OPTIONS:
   model: gpt-3.5-turbo
+# Search Provider Settings
+# Set the TAVILY_API_KEY environment variable to use Tavily for news search.
+# When TAVILY_API_KEY is present, Tavily is used automatically; otherwise
+# DuckDuckGo is used as the default search provider.
 # Application Settings
 MAX_COLUMN_NUM: 3
 OUTPUT_LANGUAGE: English

--- a/v3/requirements.txt
+++ b/v3/requirements.txt
@@ -1,4 +1,5 @@
 Agently>=3.2.2.8
 PyYAML==6.0.1
 duckduckgo_search>=5.3.0
+tavily-python>=0.5.0
 beautifulsoup4>=4.12.3

--- a/v3/workflows/tools/search.py
+++ b/v3/workflows/tools/search.py
@@ -1,26 +1,55 @@
+import os
 from duckduckgo_search import DDGS
 
-def search(keywords, **kwargs):
+def _search_tavily(keywords, **kwargs):
+    from tavily import TavilyClient
+    client = TavilyClient()
+    response = client.search(
+        query=keywords,
+        max_results=kwargs.get("max_results", 8),
+        topic="news",
+    )
     results = []
+    for index, result in enumerate(response.get("results", [])):
+        results.append({
+            "id": index,
+            "title": result.get("title", ""),
+            "brief": result.get("content", ""),
+            "url": result.get("url", ""),
+            "source": result.get("source", result.get("url", "")),
+            "date": result.get("published_date", ""),
+        })
+    return results
+
+def _search_ddgs(keywords, **kwargs):
+    results = []
+    with DDGS(proxy=kwargs.get("proxy", None)) as ddgs:
+        for index, result in enumerate(
+            ddgs.news(
+                keywords,
+                max_results=kwargs.get("max_results", 8),
+                timelimit=kwargs.get("timelimit", "d"),
+            )
+        ):
+            results.append({
+                "id": index,
+                "title": result["title"],
+                "brief": result["body"],
+                "url": result["url"],
+                "source": result["source"],
+                "date": result["date"],
+            })
+    return results
+
+def search(keywords, **kwargs):
+    provider = kwargs.get("provider", None)
+    use_tavily = provider == "tavily" or (provider is None and os.environ.get("TAVILY_API_KEY"))
     try:
-        with DDGS(proxy=kwargs.get("proxy", None)) as ddgs:
-            for index, result in enumerate(
-                ddgs.news(
-                    keywords,
-                    max_results=kwargs.get("max_results", 8),
-                    timelimit=kwargs.get("timelimit", "d"),
-                )
-            ):
-                results.append({
-                    "id": index,
-                    "title": result["title"],
-                    "brief": result["body"],
-                    "url": result["url"],
-                    "source": result["source"],
-                    "date": result["date"],
-                })
-        return results
+        if use_tavily:
+            return _search_tavily(keywords, **kwargs)
+        else:
+            return _search_ddgs(keywords, **kwargs)
     except Exception as e:
         if "logger" in kwargs:
             kwargs["logger"].error(f"[Search]: Can not search '{ keywords }'.\tError: { str(e) }")
-        return [] 
+        return []


### PR DESCRIPTION
## Summary

Adds Tavily as an optional, parallel search provider in the v3 app. When the `TAVILY_API_KEY` environment variable is present, the search function automatically routes to Tavily's news search API. Otherwise, the existing DuckDuckGo path is used unchanged.

This is an **additive** migration — no existing functionality is removed or broken.

## Changes

- **`v3/workflows/tools/search.py`** — Refactored into `_search_tavily()` and `_search_ddgs()` helpers, with the main `search()` function routing based on `TAVILY_API_KEY` env var or an explicit `provider` kwarg. Tavily results are mapped to the existing dict schema (`id`, `title`, `brief`, `url`, `source`, `date`).
- **`v3/requirements.txt`** — Added `tavily-python>=0.5.0` alongside existing `duckduckgo_search`.
- **`v3/SETTINGS.yaml`** — Documented the optional `TAVILY_API_KEY` env var and provider selection mechanism.

## Dependency changes

- Added `tavily-python>=0.5.0` to `v3/requirements.txt`

## Environment variable changes

- Added `TAVILY_API_KEY` — when set, Tavily is used automatically; when absent, DuckDuckGo remains the default

## Notes for reviewers

- The `provider` kwarg on `search()` allows callers to explicitly choose `"tavily"` or `"ddgs"` regardless of the env var.
- Error handling is preserved: failures in either provider are caught and logged via the existing `logger` kwarg pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Automated Review

- Passed after 1 attempt(s)
- Final review: The v3-app Tavily migration is correct and well-scoped. The synchronous `TavilyClient` is appropriate for the v3 synchronous workflow (contrasted correctly against the `AsyncTavilyClient` used in the prerequisite root-v4-app unit). The result schema (id, title, brief, url, source, date) is fully preserved for downstream compatibility. The auto-detection logic via `TAVILY_API_KEY` env var is sound, `requirements.txt` is updated, and `SETTINGS.yaml` has a clear comment. No dead code, no unintended changes, and the DuckDuckGo fallback is preserved.
